### PR TITLE
Bugfix: Run the selected problem's code when teams Test in VSCode

### DIFF
--- a/extension/bwcontest/src/problemPanel.ts
+++ b/extension/bwcontest/src/problemPanel.ts
@@ -143,7 +143,7 @@ export class BWPanel {
 			vscode.window.showErrorMessage('Already Running');
 			return;
 		}
-		const problem = this.problemData.find((p) => (p.id = problemId));
+		const problem = this.problemData.find((p) => (p.id === problemId));
 		if (problem === undefined) {
 			return;
 		}


### PR DESCRIPTION
It was previously always picking the first problem from the list (with a non-zero id).