### PR TITLE
Sandbox: Ensure runs are serialized, add detailed logging

### DIFF
--- a/web/src/routes/api/submission/+server.ts
+++ b/web/src/routes/api/submission/+server.ts
@@ -9,7 +9,7 @@ export const GET = (async () => {
 	const submissions = await db.submission.findMany({
 		where: { state: SubmissionState.Queued },
 		orderBy: { createdAt: 'asc' },
-		include: { problem: true },
+		include: { problem: true, contest: true, team: true },
 		take: 1
 	});
 	if (submissions.length !== 0) {
@@ -17,8 +17,10 @@ export const GET = (async () => {
 			success: true,
 			submission: {
 				id: submissions[0].id,
-				contestId: submissions[0].contestId,
-				teamId: submissions[0].teamId,
+				contestId: submissions[0].contest.id,
+				contestName: submissions[0].contest.name,
+				teamId: submissions[0].team.id,
+				teamName: submissions[0].team.name,
 				problem: {
 					id: submissions[0].problemId,
 					pascalName: submissions[0].problem.pascalName,


### PR DESCRIPTION
Specific fixes to ensure runs are serialized:

- Added missing await when starting clone/run
- The runJava method now has a single exit path that can only execute when the process has guaranteed been 'close'd. The timeout detection previously sent SIGKILL and assumed it worked, but it was not working on my machine and the student code would continue to run indefinitely after returning.
- To get the SIGKILL to kill the submitted app's process, I added end/destroy calls to the process stdin/stdout/stderr streams.

Added lots of logging while diagnosing these issues, and it seems useful to keep. As part of this, the contest/team names are now included in the 'submissions' web api.

Also, I've structured the result data in more detail within the Sandbox, tracking whether a run succeeded or the way in which it failed. I'm collapsing these back down to just a string "output" with the preexisting failure markers (e.g. "[Timeout after 30 seconds]"), but would like to pass this over to the site/DB in a structured form eventually.