### PR TITLE
Extension: make sidebar background color use theme color

### DIFF
--- a/extension/bwcontest/src/SidebarProvider.ts
+++ b/extension/bwcontest/src/SidebarProvider.ts
@@ -327,7 +327,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                     const vscode = acquireVsCodeApi();
                 </script>
 			</head>
-            <body>
+            <body style="background-color: var(--vscode-sideBar-background)">
 			</body>
             <script nonce="${nonce}" src="${scriptUri}"></script>
 			</html>`;


### PR DESCRIPTION
Note that we can't make this change directly in `media/vscode.css` because then the Test/Submit page background is wrong.

There's other style issues (most notably the buttons in the sidebar), but the other extensions use monaco-workbench/monach-editor classes for lots of style things, and we don't reference any of that currently. Since we'd have to decide if/how to incorporate all that, I've just fixed this specific background issue for now.