### PR TITLE
Judge Response Picker

### DIFF
--- a/web/src/routes/admin/submissions/[submissionId]/+page.svelte
+++ b/web/src/routes/admin/submissions/[submissionId]/+page.svelte
@@ -330,11 +330,11 @@
 				: 'pendingIncorrect'}"
 		data-bs-theme={$theme}
 	>
-		<h3>
+		<h3 class="pb-1">
 			Grade Attempt #{data.submissionHistory.map((s) => s.id).indexOf(data.submission.id) + 1}
 		</h3>
 		<form method="POST" action="?/submitGrade" use:enhanceConfirmGrading>
-			<div class="mb-1">
+			<div class="pb-2">
 				<span class="h5" style="display: inline;">Response: </span>
 				<select
 					bind:this={judgeResponsePicker}


### PR DESCRIPTION
Adds a dropdown for picking from a predefined list of judge responses, with an option to customize the text

**NOTE**: I know the _title_ and _message_ properties are identical for all of the categories in this PR. But, I think we might want more descriptive text in the _message_ part, just need to decide what that should be.

Vid available in discord, but looks like this:
![image](https://github.com/orosmatthew/bw-hspc-contest-env/assets/235241/a8613028-5e70-4346-88eb-a5b4ff8916af)