### PR TITLE
Extension Problem Panel: problem name tab improvements

### DIFF
--- a/extension/bwcontest/webviews/components/ProblemPanel.svelte
+++ b/extension/bwcontest/webviews/components/ProblemPanel.svelte
@@ -146,6 +146,13 @@
 		border: none;
 		cursor: pointer;
 		text-align: center;
+		margin-left: 2px;
+		margin-right: 2px;
+		border: 1px solid var(--vscode-checkbox-border);
+	}
+
+	.tab.active {
+		border: 1px solid var(--vscode-checkbox-selectBorder);
 	}
 
 	.tab.inactive {

--- a/extension/bwcontest/webviews/components/ProblemPanel.svelte
+++ b/extension/bwcontest/webviews/components/ProblemPanel.svelte
@@ -137,9 +137,7 @@
 	.tab-container {
 		display: flex;
 		flex-direction: row;
-		align-items: center;
 		justify-content: space-between;
-		height: 30px;
 		margin-bottom: 10px;
 	}
 

--- a/extension/bwcontest/webviews/components/ProblemPanel.svelte
+++ b/extension/bwcontest/webviews/components/ProblemPanel.svelte
@@ -96,7 +96,7 @@
 				}}
 				id={`problem_${problem.id}`}
 				type="button"
-				class={'tab ' + (activeProblemIndex === i ? 'active' : '')}>{problem.name}</button
+				class={'tab ' + (activeProblemIndex === i ? 'active' : 'inactive')}>{problem.name}</button
 			>
 		{/each}
 	</div>
@@ -150,8 +150,9 @@
 		text-align: center;
 	}
 
-	.tab.active {
-		background-color: rgb(95, 103, 118);
+	.tab.inactive {
+		color: var(--vscode-tab-inactiveForeground);
+		background-color: var(--vscode-tab-inactiveBackground);
 	}
 
 	.loader {


### PR DESCRIPTION
- Invert previous colors (blue now means selected and gray means unselected)
- Consistent tab heights when problem titles have different lengths
- Add a bit of space between buttons and borders

![image](https://github.com/orosmatthew/bw-hspc-contest-env/assets/235241/3e08f950-458f-4ef6-8c28-0cbc95072f20)
